### PR TITLE
[Dev] 일부 코드 리팩토링 및 API 수정 (#19)

### DIFF
--- a/src/main/java/com/cau/socdoc/component/KakaoPharInfo.java
+++ b/src/main/java/com/cau/socdoc/component/KakaoPharInfo.java
@@ -1,6 +1,6 @@
 package com.cau.socdoc.component;
 
-import com.cau.socdoc.dto.response.ResponseKakaoDto;
+import com.cau.socdoc.dto.response.kakao.ResponseKakaoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/cau/socdoc/domain/User.java
+++ b/src/main/java/com/cau/socdoc/domain/User.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 

--- a/src/main/java/com/cau/socdoc/dto/request/CreateUserDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/CreateUserDto.java
@@ -1,10 +1,10 @@
 package com.cau.socdoc.dto.request;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
+@NoArgsConstructor
 public class CreateUserDto {
 
     private String userId;

--- a/src/main/java/com/cau/socdoc/dto/request/CreateUserDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/CreateUserDto.java
@@ -1,10 +1,10 @@
 package com.cau.socdoc.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@Builder
 public class CreateUserDto {
 
     private String userId;

--- a/src/main/java/com/cau/socdoc/dto/request/RequestLikeDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/RequestLikeDto.java
@@ -1,8 +1,10 @@
 package com.cau.socdoc.dto.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class RequestLikeDto {
 
     private String userId;

--- a/src/main/java/com/cau/socdoc/dto/request/RequestSimpleHospitalDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/RequestSimpleHospitalDto.java
@@ -1,8 +1,10 @@
 package com.cau.socdoc.dto.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class RequestSimpleHospitalDto {
 
     private String address1;

--- a/src/main/java/com/cau/socdoc/dto/response/kakao/Document.java
+++ b/src/main/java/com/cau/socdoc/dto/response/kakao/Document.java
@@ -1,4 +1,4 @@
-package com.cau.socdoc.dto.response;
+package com.cau.socdoc.dto.response.kakao;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/cau/socdoc/dto/response/kakao/Meta.java
+++ b/src/main/java/com/cau/socdoc/dto/response/kakao/Meta.java
@@ -1,4 +1,4 @@
-package com.cau.socdoc.dto.response;
+package com.cau.socdoc.dto.response.kakao;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/cau/socdoc/dto/response/kakao/ResponseKakaoDto.java
+++ b/src/main/java/com/cau/socdoc/dto/response/kakao/ResponseKakaoDto.java
@@ -1,5 +1,7 @@
-package com.cau.socdoc.dto.response;
+package com.cau.socdoc.dto.response.kakao;
 
+import com.cau.socdoc.dto.response.kakao.Document;
+import com.cau.socdoc.dto.response.kakao.Meta;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/cau/socdoc/dto/response/kakao/SameName.java
+++ b/src/main/java/com/cau/socdoc/dto/response/kakao/SameName.java
@@ -1,4 +1,4 @@
-package com.cau.socdoc.dto.response;
+package com.cau.socdoc.dto.response.kakao;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/cau/socdoc/repository/impl/HospitalRepositoryImpl.java
+++ b/src/main/java/com/cau/socdoc/repository/impl/HospitalRepositoryImpl.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 @Repository
-@Slf4j
 public class HospitalRepositoryImpl implements HospitalRepository {
 
     // 모든 병원 ID 조회

--- a/src/main/java/com/cau/socdoc/service/impl/HospitalServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/HospitalServiceImpl.java
@@ -9,11 +9,11 @@ import com.cau.socdoc.repository.HospitalRepository;
 import com.cau.socdoc.repository.LikeRepository;
 import com.cau.socdoc.repository.ReviewRepository;
 import com.cau.socdoc.service.HospitalService;
+import com.cau.socdoc.util.MessageUtil;
 import com.cau.socdoc.util.api.ResponseCode;
 import com.cau.socdoc.util.exception.HospitalException;
 import com.cau.socdoc.util.exception.LikeException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,7 +55,8 @@ public class HospitalServiceImpl implements HospitalService {
     @Override
     @Transactional(readOnly = true)
     public List<ResponseSimpleHospitalDto> findHospitalByTypeAndAddress(String type, String address1, String address2, int pageNum) throws ExecutionException, InterruptedException {
-        List<Hospital> hospitals = hospitalRepository.findHospitalByTypeAndAddress(type, address1, address2, pageNum);
+        String hospitalType = MessageUtil.codeToHospitalType(type);
+        List<Hospital> hospitals = hospitalRepository.findHospitalByTypeAndAddress(hospitalType, address1, address2, pageNum);
         return hospitals.stream().map(hospital -> {
             try {
                 return hospitalToSimpleHospitalDto(hospital);

--- a/src/main/java/com/cau/socdoc/service/impl/HospitalServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/HospitalServiceImpl.java
@@ -3,6 +3,8 @@ package com.cau.socdoc.service.impl;
 import com.cau.socdoc.component.KakaoPharInfo;
 import com.cau.socdoc.domain.Hospital;
 import com.cau.socdoc.dto.response.*;
+import com.cau.socdoc.dto.response.kakao.Document;
+import com.cau.socdoc.dto.response.kakao.ResponseKakaoDto;
 import com.cau.socdoc.repository.HospitalRepository;
 import com.cau.socdoc.repository.LikeRepository;
 import com.cau.socdoc.repository.ReviewRepository;

--- a/src/main/java/com/cau/socdoc/service/impl/HospitalServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/HospitalServiceImpl.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class HospitalServiceImpl implements HospitalService {

--- a/src/main/java/com/cau/socdoc/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/UserServiceImpl.java
@@ -28,9 +28,6 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public ResponseUserInfoDto getUserInfo(String userId) throws ExecutionException, InterruptedException {
         User user = userRepository.findUserById(userId);
-        if(user == null) {
-            return null;
-        }
         return ResponseUserInfoDto.builder()
                 .userId(user.getUserId())
                 .userName(user.getUserName())

--- a/src/main/java/com/cau/socdoc/util/MessageUtil.java
+++ b/src/main/java/com/cau/socdoc/util/MessageUtil.java
@@ -1,5 +1,7 @@
 package com.cau.socdoc.util;
 
+import com.cau.socdoc.util.api.ResponseCode;
+import com.cau.socdoc.util.exception.HospitalException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +30,61 @@ public class MessageUtil {
 
     // 좋아요
     public static final String COLLECTION_LIKE = "like";
+
+    public static String codeToHospitalType(String type){
+        switch(type){
+            case "D001":
+                return "내과";
+            case "D002":
+                return "소아청소년과";
+            case "D003":
+                return "신경과";
+            case "D004":
+                return "정신건강의학과";
+            case "D005":
+                return "피부과";
+            case "D006":
+                return "외과";
+            case "D007":
+                return "흉부외과";
+            case "D008":
+                return "정형외과";
+            case "D009":
+                return "신경외과";
+            case "D010":
+                return "성형외과";
+            case "D011":
+                return "산부인과";
+            case "D012":
+                return "안과";
+            case "D013":
+                return "이비인후과";
+            case "D014":
+                return "비뇨기과";
+            case "D016":
+                return "재활의학과";
+            case "D017":
+                return "마취통증의학과";
+            case "D018":
+                return "영상의학과";
+            case "D019":
+                return "치료방사선과";
+            case "D020":
+                return "임상병리과";
+            case "D021":
+                return "해부병리과";
+            case "D022":
+                return "가정의학과";
+            case "D023":
+                return "핵의학과";
+            case "D024":
+                return "응급의학과";
+            case "D026":
+                return "치과";
+            case "D034":
+                return "구강악안면외과";
+            default: // 잘못된 병원코드
+                throw new HospitalException(ResponseCode.BAD_REQUEST);
+        }
+    }
 }

--- a/src/main/java/com/cau/socdoc/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cau/socdoc/util/exception/GlobalExceptionHandler.java
@@ -21,4 +21,9 @@ public class GlobalExceptionHandler {
     public ApiResponse<Void> handleHospitalException(HospitalException e) {
         return ApiResponse.fail(e.getResponseCode());
     }
+
+    @ExceptionHandler(LikeException.class)
+    public ApiResponse<Void> handleLikeException(LikeException e) {
+        return ApiResponse.fail(e.getResponseCode());
+    }
 }


### PR DESCRIPTION
## Summary
* 약국조회를 위해 Kakao 서버에서 수신하는 ResponseDto 별도 패키지로 분리
* GlobalExceptionHandler LikeException 누락 수정
* RequestDto에 기본생성자 누락된 버그 수정
* 불필요한 어노테이션 및 일부 로직 정리
* 분과별 조회 API 기능 쿼리 파라미터 type을 분과명이 아닌 분과코드를 받도록 수정
* 분과코드에 대응하는 분과명 추출 메서드 MessageUtil에 추가

## Description