### PR TITLE
[Dev] 요청 데이터의 유효성 검사 추가 (#21)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 	// Webclient dependency
 	implementation platform('org.springframework.boot:spring-boot-dependencies:2.7.15')
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// Validation dependency
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cau/socdoc/controller/HospitalController.java
+++ b/src/main/java/com/cau/socdoc/controller/HospitalController.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -31,13 +32,13 @@ public class HospitalController {
 
     // 특정 지역의 특정 분과 병원 조회
     @GetMapping("/list/{type}")
-    public ApiResponse<List<ResponseSimpleHospitalDto>> findHospitalByTypeAndAddress(@PathVariable String type, @RequestBody RequestSimpleHospitalDto dto) throws ExecutionException, InterruptedException {
+    public ApiResponse<List<ResponseSimpleHospitalDto>> findHospitalByTypeAndAddress(@PathVariable String type, @RequestBody @Valid RequestSimpleHospitalDto dto) throws ExecutionException, InterruptedException {
         return ApiResponse.success(hospitalService.findHospitalByTypeAndAddress(type, dto.getAddress1(), dto.getAddress2(), dto.getPageNum()), ResponseCode.HOSPITAL_READ_SUCCESS.getMessage());
     }
 
     // 특정 지역의 병원 조회
     @GetMapping("/list")
-    public ApiResponse<List<ResponseSimpleHospitalDto>> findHospitalByTypeAndAddress(@RequestBody RequestSimpleHospitalDto dto) throws ExecutionException, InterruptedException {
+    public ApiResponse<List<ResponseSimpleHospitalDto>> findHospitalByTypeAndAddress(@RequestBody @Valid RequestSimpleHospitalDto dto) throws ExecutionException, InterruptedException {
         return ApiResponse.success(hospitalService.findHospitalByAddress(dto.getAddress1(), dto.getAddress2(), dto.getPageNum()), ResponseCode.HOSPITAL_READ_SUCCESS.getMessage());
     }
 
@@ -49,14 +50,14 @@ public class HospitalController {
 
     // 유저가 병원에 좋아요 누르기
     @PostMapping("/like/user")
-    public ApiResponse<Void> likeHospital(@RequestBody RequestLikeDto dto) throws ExecutionException, InterruptedException {
+    public ApiResponse<Void> likeHospital(@RequestBody @Valid RequestLikeDto dto) throws ExecutionException, InterruptedException {
         hospitalService.saveLike(dto.getUserId(), dto.getHospitalId());
         return ApiResponse.success(null, ResponseCode.LIKE_CREATE_SUCCESS.getMessage());
     }
 
     // 유저가 병원에 좋아요 취소
     @DeleteMapping("/like/user")
-    public ApiResponse<Void> unlikeHospital(@RequestBody RequestLikeDto dto) throws ExecutionException, InterruptedException {
+    public ApiResponse<Void> unlikeHospital(@RequestBody @Valid RequestLikeDto dto) throws ExecutionException, InterruptedException {
         hospitalService.deleteLike(dto.getUserId(), dto.getHospitalId());
         return ApiResponse.success(null, ResponseCode.LIKE_DELETE_SUCCESS.getMessage());
     }

--- a/src/main/java/com/cau/socdoc/controller/ReviewController.java
+++ b/src/main/java/com/cau/socdoc/controller/ReviewController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -40,14 +41,14 @@ public class ReviewController {
     // 리뷰 생성
     @Operation(summary = "[리뷰] 리뷰 생성", description = "리뷰를 생성합니다.")
     @PostMapping("/create")
-    public ApiResponse<String> createReview(CreateReviewDto createReviewDto) throws ExecutionException, InterruptedException {
+    public ApiResponse<String> createReview(@RequestBody @Valid CreateReviewDto createReviewDto) throws ExecutionException, InterruptedException {
         return ApiResponse.success(reviewService.createReview(createReviewDto), ResponseCode.REVIEW_CREATE_SUCCESS.getMessage());
     }
 
     // 리뷰 수정
     @Operation(summary = "[리뷰] 리뷰 수정", description = "리뷰를 수정합니다.")
     @PutMapping("/update")
-    public ApiResponse<Void> updateReview(UpdateReviewDto updateReviewDto) throws ExecutionException, InterruptedException {
+    public ApiResponse<Void> updateReview(@RequestBody @Valid UpdateReviewDto updateReviewDto) throws ExecutionException, InterruptedException {
         reviewService.updateReview(updateReviewDto);
         return ApiResponse.success(null, ResponseCode.REVIEW_UPDATE_SUCCESS.getMessage());
     }

--- a/src/main/java/com/cau/socdoc/controller/UserController.java
+++ b/src/main/java/com/cau/socdoc/controller/UserController.java
@@ -5,6 +5,8 @@ import com.cau.socdoc.dto.request.UpdateUserAddressDto;
 import com.cau.socdoc.dto.request.UpdateUserNameDto;
 import com.cau.socdoc.dto.response.ResponseUserInfoDto;
 import com.cau.socdoc.service.UserService;
+import com.cau.socdoc.util.api.ResponseCode;
+import com.cau.socdoc.util.exception.UserException;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import io.swagger.annotations.Api;
@@ -34,21 +36,25 @@ public class UserController {
     // 로그인
     @Operation(summary = "[유저] 로그인", description = "Firebase Auth idToken을 통해 유저 정보를 조회합니다. 만약 유저 정보가 없다면 유저 정보를 생성하고 정보를 반환합니다.")
     @PostMapping("/login")
-    public ResponseUserInfoDto login(String idToken) throws FirebaseAuthException, ExecutionException, InterruptedException {
+    public ResponseUserInfoDto login(@RequestHeader String firebaseToken) {
         // uid를 통해 유저 정보를 가져온다.
-        String uid = firebaseAuth.verifyIdToken(idToken).getUid();
-
-        // 유저 정보가 없다면 유저 정보를 생성한다.
-        if(userService.getUserInfo(uid) == null) {
-            userService.createUser(CreateUserDto.builder()
-                    .userId(uid)
-                    .userName(firebaseAuth.getUser(uid).getDisplayName())
-                    .userEmail(firebaseAuth.getUser(uid).getEmail())
-                    .address1("서울특별시")
-                    .address2("동작구")
-                    .build());
+        try {
+            String uid = firebaseAuth.verifyIdToken(firebaseToken).getUid();
+            if (userService.getUserInfo(uid) == null) {
+                userService.createUser(CreateUserDto.builder()
+                        .userId(uid)
+                        .userName(firebaseAuth.getUser(uid).getDisplayName())
+                        .userEmail(firebaseAuth.getUser(uid).getEmail())
+                        .address1("서울특별시")
+                        .address2("동작구")
+                        .build());
+            }
+            return userService.getUserInfo(uid);
+        } catch (FirebaseAuthException e) {
+            throw new UserException(ResponseCode.USER_NOT_FOUND);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new UserException(ResponseCode.INTERNAL_SERVER_ERROR);
         }
-        return userService.getUserInfo(uid);
     }
 
     // 유저 주소 수정

--- a/src/main/java/com/cau/socdoc/controller/UserController.java
+++ b/src/main/java/com/cau/socdoc/controller/UserController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.concurrent.ExecutionException;
 
 @Api(tags = "user")
@@ -53,14 +54,14 @@ public class UserController {
     // 유저 주소 수정
     @Operation(summary = "[유저] 유저 주소 수정", description = "userId를 통해 유저 주소를 수정합니다.")
     @PutMapping("/update/address")
-    public void updateUserAddress(@RequestBody UpdateUserAddressDto updateUserAddressDto) throws ExecutionException, InterruptedException {
+    public void updateUserAddress(@RequestBody @Valid UpdateUserAddressDto updateUserAddressDto) throws ExecutionException, InterruptedException {
         userService.updateUserAddress(updateUserAddressDto);
     }
 
     // 유저 이름 수정
     @Operation(summary = "[유저] 유저 이름 수정", description = "userId를 통해 유저 이름을 수정합니다.")
     @PutMapping("/update/name")
-    public void updateUserName(@RequestBody UpdateUserNameDto updateUserNameDto) throws ExecutionException, InterruptedException {
+    public void updateUserName(@RequestBody @Valid UpdateUserNameDto updateUserNameDto) throws ExecutionException, InterruptedException {
         userService.updateUserName(updateUserNameDto);
     }
 

--- a/src/main/java/com/cau/socdoc/dto/request/CreateReviewDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/CreateReviewDto.java
@@ -5,22 +5,25 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor
 public class CreateReviewDto {
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String userId; // 작성한 유저 ID
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String hospitalId; // 리뷰남긴 병원 ID
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String content; // 내용
 
-
+    @DecimalMin(value = "1", message = MessageUtil.ONE_TO_FIVE)
+    @DecimalMax(value = "5", message = MessageUtil.ONE_TO_FIVE)
     private int rating; // 1 ~ 5
 
     private MultipartFile image; // 사진

--- a/src/main/java/com/cau/socdoc/dto/request/CreateReviewDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/CreateReviewDto.java
@@ -1,16 +1,27 @@
 package com.cau.socdoc.dto.request;
 
+import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @NoArgsConstructor
 public class CreateReviewDto {
 
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String userId; // 작성한 유저 ID
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String hospitalId; // 리뷰남긴 병원 ID
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String content; // 내용
+
+
     private int rating; // 1 ~ 5
+
     private MultipartFile image; // 사진
 }

--- a/src/main/java/com/cau/socdoc/dto/request/CreateUserDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/CreateUserDto.java
@@ -1,15 +1,28 @@
 package com.cau.socdoc.dto.request;
 
+import com.cau.socdoc.util.MessageUtil;
 import lombok.Builder;
 import lombok.Getter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @Builder
 public class CreateUserDto {
 
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String userId;
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String userName;
+
+    @Email(message = MessageUtil.INVALID_EMAIL_FORMAT)
     private String userEmail;
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String address1; // 서울시
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String address2; // 동작구
 }

--- a/src/main/java/com/cau/socdoc/dto/request/CreateUserDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/CreateUserDto.java
@@ -5,24 +5,24 @@ import lombok.Builder;
 import lombok.Getter;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @Builder
 public class CreateUserDto {
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String userId;
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String userName;
 
     @Email(message = MessageUtil.INVALID_EMAIL_FORMAT)
     private String userEmail;
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String address1; // 서울시
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String address2; // 동작구
 }

--- a/src/main/java/com/cau/socdoc/dto/request/RequestLikeDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/RequestLikeDto.java
@@ -1,12 +1,18 @@
 package com.cau.socdoc.dto.request;
 
+import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @NoArgsConstructor
 public class RequestLikeDto {
 
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String userId;
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String hospitalId;
 }

--- a/src/main/java/com/cau/socdoc/dto/request/RequestLikeDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/RequestLikeDto.java
@@ -4,15 +4,15 @@ import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor
 public class RequestLikeDto {
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String userId;
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String hospitalId;
 }

--- a/src/main/java/com/cau/socdoc/dto/request/RequestSimpleHospitalDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/RequestSimpleHospitalDto.java
@@ -1,13 +1,22 @@
 package com.cau.socdoc.dto.request;
 
+import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @NoArgsConstructor
 public class RequestSimpleHospitalDto {
 
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String address1;
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String address2;
+
+    @DecimalMin(value = "1", message = MessageUtil.LARGER_THAN_ZERO)
     private int pageNum;
 }

--- a/src/main/java/com/cau/socdoc/dto/request/RequestSimpleHospitalDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/RequestSimpleHospitalDto.java
@@ -5,16 +5,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 
 @Getter
 @NoArgsConstructor
 public class RequestSimpleHospitalDto {
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String address1;
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String address2;
 
     @DecimalMin(value = "1", message = MessageUtil.LARGER_THAN_ZERO)

--- a/src/main/java/com/cau/socdoc/dto/request/UpdateReviewDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/UpdateReviewDto.java
@@ -6,16 +6,16 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor
 public class UpdateReviewDto {
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String reviewId; // 리뷰 고유 ID
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String content; // 내용
 
     @DecimalMin(value = "1", message = MessageUtil.ONE_TO_FIVE)

--- a/src/main/java/com/cau/socdoc/dto/request/UpdateReviewDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/UpdateReviewDto.java
@@ -1,13 +1,24 @@
 package com.cau.socdoc.dto.request;
 
+import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @NoArgsConstructor
 public class UpdateReviewDto {
 
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String reviewId; // 리뷰 고유 ID
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String content; // 내용
+
+    @DecimalMin(value = "1", message = MessageUtil.ONE_TO_FIVE)
+    @DecimalMax(value = "5", message = MessageUtil.ONE_TO_FIVE)
     private int rating; // 1 ~ 5
 }

--- a/src/main/java/com/cau/socdoc/dto/request/UpdateUserAddressDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/UpdateUserAddressDto.java
@@ -4,18 +4,18 @@ import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor
 public class UpdateUserAddressDto {
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String userId;
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String address1;
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String address2;
 }

--- a/src/main/java/com/cau/socdoc/dto/request/UpdateUserAddressDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/UpdateUserAddressDto.java
@@ -1,13 +1,21 @@
 package com.cau.socdoc.dto.request;
 
+import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @NoArgsConstructor
 public class UpdateUserAddressDto {
 
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String userId;
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String address1;
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String address2;
 }

--- a/src/main/java/com/cau/socdoc/dto/request/UpdateUserNameDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/UpdateUserNameDto.java
@@ -4,15 +4,15 @@ import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor
 public class UpdateUserNameDto {
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String userId;
 
-    @NotEmpty(message = MessageUtil.NOT_EMPTY)
+    @NotBlank(message = MessageUtil.NOT_BLANK)
     private String userName;
 }

--- a/src/main/java/com/cau/socdoc/dto/request/UpdateUserNameDto.java
+++ b/src/main/java/com/cau/socdoc/dto/request/UpdateUserNameDto.java
@@ -1,12 +1,18 @@
 package com.cau.socdoc.dto.request;
 
+import com.cau.socdoc.util.MessageUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @NoArgsConstructor
 public class UpdateUserNameDto {
 
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String userId;
+
+    @NotEmpty(message = MessageUtil.NOT_EMPTY)
     private String userName;
 }

--- a/src/main/java/com/cau/socdoc/dto/response/ResponseReviewDto.java
+++ b/src/main/java/com/cau/socdoc/dto/response/ResponseReviewDto.java
@@ -3,6 +3,7 @@ package com.cau.socdoc.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.util.annotation.Nullable;
 
 @Getter
 @Builder
@@ -13,5 +14,6 @@ public class ResponseReviewDto {
     private String content; // 내용
     private String createdAt; // 생성일
     private int rating; // 1 ~ 5
+    @Nullable
     private MultipartFile image; // 사진
 }

--- a/src/main/java/com/cau/socdoc/repository/impl/ReviewRepositoryImpl.java
+++ b/src/main/java/com/cau/socdoc/repository/impl/ReviewRepositoryImpl.java
@@ -48,7 +48,9 @@ public class ReviewRepositoryImpl implements ReviewRepository {
         ApiFuture<DocumentReference> docRef = db.collection(MessageUtil.COLLECTION_REVIEW).add(review);
 
         // 수신한 이미지 디렉토리에 저장
-        image.transferTo(new File(IMAGE_DIR+ docRef.get().getId() + ".png"));
+        if(image != null){
+            image.transferTo(new File(IMAGE_DIR+ docRef.get().getId() + ".png"));
+        }
         return docRef.get().getId();
     }
 

--- a/src/main/java/com/cau/socdoc/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/ReviewServiceImpl.java
@@ -87,8 +87,7 @@ public class ReviewServiceImpl implements ReviewService {
             IOUtils.copy(input, os);
             return new CommonsMultipartFile(fileItem);
         } else {
-            // 이미지 파일이 존재하지 않을 경우 예외 처리
-            throw new FileNotFoundException("이미지 파일을 찾을 수 없습니다.");
+            return null;
         }
     }
 }

--- a/src/main/java/com/cau/socdoc/util/MessageUtil.java
+++ b/src/main/java/com/cau/socdoc/util/MessageUtil.java
@@ -8,6 +8,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MessageUtil {
 
+    // 유효성 검사 관련
+    public static final String NOT_EMPTY = "빈 값이 입력되었습니다.";
+    public static final String ONE_TO_FIVE = "null 값이 입력되었습니다.";
+    public static final String LARGER_THAN_ZERO = "0보다 큰 값을 입력해주세요.";
+    public static final String INVALID_EMAIL_FORMAT = "이메일 형식이 올바르지 않습니다.";
+
     // 유저
     public static final String COLLECTION_USER = "user";
     public static final String USER_ID = "userId";

--- a/src/main/java/com/cau/socdoc/util/MessageUtil.java
+++ b/src/main/java/com/cau/socdoc/util/MessageUtil.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 public class MessageUtil {
 
     // 유효성 검사 관련
-    public static final String NOT_EMPTY = "빈 값이 입력되었습니다.";
-    public static final String ONE_TO_FIVE = "null 값이 입력되었습니다.";
+    public static final String NOT_BLANK = "null 또는 공백이 입력되었습니다.";
+    public static final String ONE_TO_FIVE = "1~5 사이의 값을 입력해주세요.";
     public static final String LARGER_THAN_ZERO = "0보다 큰 값을 입력해주세요.";
     public static final String INVALID_EMAIL_FORMAT = "이메일 형식이 올바르지 않습니다.";
 

--- a/src/main/java/com/cau/socdoc/util/api/ApiResponse.java
+++ b/src/main/java/com/cau/socdoc/util/api/ApiResponse.java
@@ -23,6 +23,10 @@ public class ApiResponse<T> {
         return new ApiResponse<T>(new ApiHeader(SUCCESS, "SUCCESS"), data, message);
     }
 
+    public static <T> ApiResponse<T> fail(ResponseCode responseCode, T data) {
+        return new ApiResponse<T>(new ApiHeader(responseCode.getHttpStatusCode(), responseCode.getMessage()), data, responseCode.getMessage());
+    }
+
     public static <T> ApiResponse<T> fail(ResponseCode responseCode) {
         return new ApiResponse<T>(new ApiHeader(responseCode.getHttpStatusCode(), responseCode.getMessage()), null, responseCode.getMessage());
     }

--- a/src/main/java/com/cau/socdoc/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cau/socdoc/util/exception/GlobalExceptionHandler.java
@@ -1,8 +1,16 @@
 package com.cau.socdoc.util.exception;
 
 import com.cau.socdoc.util.api.ApiResponse;
+import com.cau.socdoc.util.api.ResponseCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -25,5 +33,28 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(LikeException.class)
     public ApiResponse<Void> handleLikeException(LikeException e) {
         return ApiResponse.fail(e.getResponseCode());
+    }
+
+    @ExceptionHandler(ExecutionException.class)
+    public ApiResponse<Void> handleExecutionException(ExecutionException e) {
+        return ApiResponse.fail(ResponseCode.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(InterruptedException.class)
+    public ApiResponse<Void> handleInterruptedException(InterruptedException e) {
+        return ApiResponse.fail(ResponseCode.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class) // 요청의 유효성 검사 실패 시
+    @ResponseStatus(HttpStatus.BAD_REQUEST) // 400 Bad Request로 응답 반환
+    public ApiResponse<Map<String, String>> handleInValidRequestException(MethodArgumentNotValidException e) {
+        // 에러가 발생한 객체 내 필드와 대응하는 에러 메시지를 map에 저장하여 반환
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(error -> {
+            String fieldName = error.getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        return ApiResponse.fail(ResponseCode.BAD_REQUEST, errors);
     }
 }


### PR DESCRIPTION
## Summary
### 유효성검사
* Controller RequestDto에 유효성검사 적용
* RequestDto 각 필드에 데이터 검사 어노테이션 추가
* 데이터 검사 실패 시 호출되는 메시지는 MessageUtil에서 통합적으로 관리

### 기타
* 로그인 메서드 @RequestHeader 누락 수정
* Review 생성 기능 사진 없으면 사진 저장 로직 생략하도록 수정
* Review 조회 기능 사진 없으면 사진 불러오기 로직 생략하도록 수정

## Description
* 클라이언트는 이제 아래와 같은 상황에 대해서 서버로부터 예외처리를 받게 됩니다.
* 이메일 필드를 전송할 때 Email 형식에 어긋난 경우
* 그 외 다른 String 필드를 검사할 때 null이거나, " "이거나, ""인 경우
* 또한 리뷰 점수는 1~5점으로 한정하며, 만약 0점 이하 6점 이상이 요청에 포함된 경우
* 요청한 페이지 값이 0 이하의 정수인 경우

## 예시 이미지
![image](https://github.com/SOCDOC-CAU/SOCDOC-BE/assets/53044069/c2ec3d78-dc8d-46dd-8082-2d938eb1c525)
![image](https://github.com/SOCDOC-CAU/SOCDOC-BE/assets/53044069/6654a658-ce1d-477e-ab08-69ef7254e8bf)
