### PR TITLE
[fix] userName이 생성되지 않는 경우에 대한 예외처리 추가 (#33)

### DIFF
--- a/src/main/java/com/cau/socdoc/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/cau/socdoc/repository/impl/UserRepositoryImpl.java
@@ -31,7 +31,15 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public String findNameById(String userId) throws ExecutionException, InterruptedException {
         Firestore db = FirestoreClient.getFirestore();
-        return db.collection(MessageUtil.COLLECTION_USER).document(userId).get().get().getString("userName");
+        DocumentSnapshot d = db.collection(MessageUtil.COLLECTION_USER).document(userId).get().get();
+        if (d.getString(MessageUtil.USER_NAME) == null) {
+            if (d.getString(MessageUtil.USER_EMAIL) == null) {
+                return d.getString(MessageUtil.USER_ID);
+            }
+            return d.getString(MessageUtil.USER_EMAIL);
+        } else {
+            return d.getString(MessageUtil.USER_NAME);
+        }
     }
 
     // id로 회원가입 여부 조회
@@ -47,7 +55,7 @@ public class UserRepositoryImpl implements UserRepository {
         DocumentReference docRef = db.collection(MessageUtil.COLLECTION_USER).document(userId);
         ApiFuture<DocumentSnapshot> future = docRef.get();
         DocumentSnapshot document = future.get();
-        if(!document.exists()){
+        if (!document.exists()) {
             throw new UserException(ResponseCode.USER_NOT_FOUND);
         }
         return document.toObject(User.class);
@@ -60,7 +68,7 @@ public class UserRepositoryImpl implements UserRepository {
         DocumentReference docRef = db.collection(MessageUtil.COLLECTION_USER).document(userId);
         ApiFuture<DocumentSnapshot> future = docRef.get();
         DocumentSnapshot document = future.get();
-        if(!document.exists()){
+        if (!document.exists()) {
             throw new UserException(ResponseCode.USER_NOT_FOUND);
         }
         docRef.update(MessageUtil.ADDRESS1, address1);
@@ -74,7 +82,7 @@ public class UserRepositoryImpl implements UserRepository {
         DocumentReference docRef = db.collection(MessageUtil.COLLECTION_USER).document(userId);
         ApiFuture<DocumentSnapshot> future = docRef.get();
         DocumentSnapshot document = future.get();
-        if(!document.exists()){
+        if (!document.exists()) {
             throw new UserException(ResponseCode.USER_NOT_FOUND);
         }
         docRef.update(MessageUtil.USER_NAME, userName);

--- a/src/main/java/com/cau/socdoc/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/UserServiceImpl.java
@@ -40,7 +40,7 @@ public class UserServiceImpl implements UserService {
         return ResponseUserInfoDto.builder()
                 .userId(user.getUserId())
                 .userName(user.getUserName() == null ? (user.getUserEmail()  == null ? user.getUserId() : user.getUserEmail()) : user.getUserName())
-                .userEmail(user.getUserEmail())
+                .userEmail(user.getUserEmail() == null ? user.getUserId() : user.getUserEmail())
                 .address1(user.getAddress1())
                 .address2(user.getAddress2())
                 .build();

--- a/src/main/java/com/cau/socdoc/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/UserServiceImpl.java
@@ -39,7 +39,7 @@ public class UserServiceImpl implements UserService {
         log.info("유저 정보 조회 완료: " + userId);
         return ResponseUserInfoDto.builder()
                 .userId(user.getUserId())
-                .userName(user.getUserName())
+                .userName(user.getUserName() == null ? (user.getUserEmail()  == null ? user.getUserId() : user.getUserEmail()) : user.getUserName())
                 .userEmail(user.getUserEmail())
                 .address1(user.getAddress1())
                 .address2(user.getAddress2())

--- a/src/main/java/com/cau/socdoc/util/MessageUtil.java
+++ b/src/main/java/com/cau/socdoc/util/MessageUtil.java
@@ -11,13 +11,13 @@ public class MessageUtil {
     // 유효성 검사 관련
     public static final String NOT_BLANK = "null 또는 공백이 입력되었습니다.";
     public static final String ONE_TO_FIVE = "1~5 사이의 값을 입력해주세요.";
-    public static final String LARGER_THAN_ZERO = "0보다 큰 값을 입력해주세요.";
     public static final String INVALID_EMAIL_FORMAT = "이메일 형식이 올바르지 않습니다.";
 
     // 유저
     public static final String COLLECTION_USER = "user";
     public static final String USER_ID = "userId";
     public static final String USER_NAME = "userName";
+    public static final String USER_EMAIL = "userEmail";
     public static final String ADDRESS1 = "address1";
     public static final String ADDRESS2 = "address2";
 

--- a/src/main/java/com/cau/socdoc/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cau/socdoc/util/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.cau.socdoc.util.exception;
 import com.cau.socdoc.util.api.ApiResponse;
 import com.cau.socdoc.util.api.ResponseCode;
 import com.google.firebase.auth.FirebaseAuthException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,41 +14,49 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(UserException.class)
     public ApiResponse<Void> handleUserException(UserException e) {
+        log.error(e.getMessage(), e);
         return ApiResponse.fail(e.getResponseCode());
     }
 
     @ExceptionHandler(ReviewException.class)
     public ApiResponse<Void> handleReviewException(ReviewException e) {
+        log.error(e.getMessage(), e);
         return ApiResponse.fail(e.getResponseCode());
     }
 
     @ExceptionHandler(HospitalException.class)
     public ApiResponse<Void> handleHospitalException(HospitalException e) {
+        log.error(e.getMessage(), e);
         return ApiResponse.fail(e.getResponseCode());
     }
 
     @ExceptionHandler(LikeException.class)
     public ApiResponse<Void> handleLikeException(LikeException e) {
+        log.error(e.getMessage(), e);
         return ApiResponse.fail(e.getResponseCode());
     }
 
     @ExceptionHandler(ExecutionException.class)
     public ApiResponse<Void> handleExecutionException(ExecutionException e) {
+        log.error(e.getMessage(), e);
         return ApiResponse.fail(ResponseCode.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(InterruptedException.class)
     public ApiResponse<Void> handleInterruptedException(InterruptedException e) {
+        log.error(e.getMessage(), e);
         return ApiResponse.fail(ResponseCode.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(FirebaseAuthException.class)
     public ApiResponse<Void> handleFirebaseAuthException(FirebaseAuthException e) {
+        log.error(e.getMessage(), e);
         return ApiResponse.fail(ResponseCode.FIREBASE_AUTH_ERROR);
     }
 


### PR DESCRIPTION
## Summary
* MessageUtil 메시지 수정
* 유저 이름 없을 시 유저 이메일, 유저 이메일 없을 시 유저 id로 대체하는 로직 추가

## Description
