### PR TITLE
[fix] 병원 평점 재계산 로직 추가 및 조회 기능 페이징 오류 해결

### DIFF
--- a/src/main/java/com/cau/socdoc/repository/HospitalRepository.java
+++ b/src/main/java/com/cau/socdoc/repository/HospitalRepository.java
@@ -8,8 +8,8 @@ import java.util.concurrent.ExecutionException;
 public interface HospitalRepository {
 
     List<String> findAllHospital() throws ExecutionException, InterruptedException;
-    List<Hospital> findHospitalByTypeAndAddress(String type, String address1, String address2, int pageNum) throws ExecutionException, InterruptedException;
-    List<Hospital> findHospitalByAddress(String address1, String address2, int pageNum) throws ExecutionException, InterruptedException;
+    List<Hospital> findHospitalByTypeAndAddress(String type, String address1, String address2, int pageNum, int sortType) throws ExecutionException, InterruptedException;
+    List<Hospital> findHospitalByAddress(String address1, String address2, int pageNum, int sortType) throws ExecutionException, InterruptedException;
     Hospital findHospitalDetail(String hospitalId) throws ExecutionException, InterruptedException;
     List<Hospital> findHospitalByLike(String userId) throws ExecutionException, InterruptedException;
     String findNameById(String hospitalId) throws ExecutionException, InterruptedException;

--- a/src/main/java/com/cau/socdoc/repository/ReviewRepository.java
+++ b/src/main/java/com/cau/socdoc/repository/ReviewRepository.java
@@ -12,6 +12,6 @@ public interface ReviewRepository {
     Map<String, Review> readReview(String id, int type) throws ExecutionException, InterruptedException;
     String createReview(Review review, MultipartFile image) throws ExecutionException, InterruptedException, IOException;
     void updateReview(String reviewId, String contents, int rating) throws ExecutionException, InterruptedException;
-    void deleteReview(String reviewId);
+    void deleteReview(String reviewId) throws ExecutionException, InterruptedException;
     double getReviewAverage(String hospitalId) throws ExecutionException, InterruptedException;
 }

--- a/src/main/java/com/cau/socdoc/service/impl/HospitalServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/HospitalServiceImpl.java
@@ -63,19 +63,12 @@ public class HospitalServiceImpl implements HospitalService {
     @Transactional(readOnly = true)
     public List<ResponseSimpleHospitalDto> findHospitalByTypeAndAddress(String type, String address1, String address2, int pageNum, int sortType) throws ExecutionException, InterruptedException {
         String hospitalType = MessageUtil.codeToHospitalType(type);
-        List<Hospital> hospitals = hospitalRepository.findHospitalByTypeAndAddress(hospitalType, address1, address2, pageNum);
+        List<Hospital> hospitals = hospitalRepository.findHospitalByTypeAndAddress(hospitalType, address1, address2, pageNum, sortType);
         log.info("특정 지역 특정 분과 병원 조회 완료: " + hospitalType + "- " + address1 + " " + address2);
         List<ResponseSimpleHospitalDto> dtos = new ArrayList<>();
         for (Hospital hospital : hospitals) {
             dtos.add(hospitalToSimpleHospitalDto(hospital));
         }
-        dtos.sort((o1, o2) -> {
-            if (sortType == MessageUtil.SORT_BY_NAME) {
-                return o1.getName().compareTo(o2.getName()); // 이름 오름차순
-            } else {
-                return Double.compare(o2.getRating(), o1.getRating()); // 별점 내림차순
-            }
-        });
         return dtos;
     }
 
@@ -83,19 +76,12 @@ public class HospitalServiceImpl implements HospitalService {
     @Override
     @Transactional(readOnly = true)
     public List<ResponseSimpleHospitalDto> findHospitalByAddress(String address1, String address2, int pageNum, int sortType) throws ExecutionException, InterruptedException {
-        List<Hospital> hospitals = hospitalRepository.findHospitalByAddress(address1, address2, pageNum);
+        List<Hospital> hospitals = hospitalRepository.findHospitalByAddress(address1, address2, pageNum, sortType);
         log.info("특정 지역 병원 조회 완료: " + address1 + " " + address2);
         List<ResponseSimpleHospitalDto> dtos = new ArrayList<>();
         for (Hospital hospital : hospitals) {
             dtos.add(hospitalToSimpleHospitalDto(hospital));
         }
-        dtos.sort((o1, o2) -> {
-            if (sortType == MessageUtil.SORT_BY_NAME) {
-                return o1.getName().compareTo(o2.getName()); // 이름 오름차순
-            } else {
-                return Double.compare(o2.getRating(), o1.getRating()); // 별점 내림차순
-            }
-        });
         return dtos;
     }
 

--- a/src/main/java/com/cau/socdoc/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/cau/socdoc/service/impl/ReviewServiceImpl.java
@@ -90,7 +90,7 @@ public class ReviewServiceImpl implements ReviewService {
 
     // 리뷰 삭제
     @Transactional
-    public void deleteReview(String reviewId) {
+    public void deleteReview(String reviewId) throws ExecutionException, InterruptedException {
         reviewRepository.deleteReview(reviewId);
         log.info("리뷰 삭제 완료: " + reviewId);
     }


### PR DESCRIPTION
## Summary
* 병원명 오름차순, 병원평점 내림차순 페이징 오류 없이 적용
* 단 5페이지 조회 시 50개를 가져와 40~49 인덱스를 반환하는 구조의 로직이라 후반 페이지로 갈수록 오버헤드 존재
* 병원의 rating 속성의 데이터 일관성을 보장하기 위해 리뷰 생성/수정/삭제 시 해당 병원 평점 재계산 로직 추가

## Description
